### PR TITLE
IEBH-438: added first pilot-hdc service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Required: External IP for ingress hostnames
 EXTERNAL_IP=1.2.3.4
 
+# Required: RSA public key for pilot-hdc services authentication
+# Base64 encoded RSA public key (this is a dummy one, not actually correlated with a private key)
+RSA_PUBLIC_KEY=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF0QTBrU0VwaW10VjA1WGlRcmFWQjkKQWZEZU1xRlpPcTNGU1hNOTJPbGI0NEdWR1ZqY3V5dmdVeWFDaTZiMzNhNHBHaGp4b00weGRVT2gvb0NJRUFEawo3cThBSjdRV3JmU0NyZ3ZSTW42RFNuTEJQU0d4WWlPdnExNUhIMUVsZmtTVXVSSDZNN1BKb0VkNlBFRDB5dFdLCnFNcXpiSFhFMEs2cEI3Y05vNmdCUjYwaHNjZ2FXVlhPMUtybDFEcVo5ZHVRME1CSXlIcitZU1pkRjhTUWdUOW4KWitKbGtmR2xuNWxkZDRBNXlKQUxJb0VZQW1VUW1SR0UyNlRIWHhuZS9Mclk5NmZwM3hlRFpUMHQ0d0hZYmU1WQp6S2hvT05rNjByK1h5M3hBUmNBUXNuOTlLaTFIY2oyV0tvOFkyNmpxNlVqVVkzSHBQYlB4MTBNM2pFUkpPZTF4CndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t
+
 # Required: Docker registry credentials for private image pulls
 # These are only needed once due to Terraform lifecycle.ignore_changes
 # To be removed in the future

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ k8s.log
 # Temporary files
 ignore_mds/*
 Makefile
+
+# PostgreSQL init scripts (contains sensitive schema information)
+helm_charts/postgres/postgres-init.sql

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,7 +16,7 @@ else
     if [[ -f "${SCRIPT_DIR}/.env.example" ]]; then
         echo "ERROR: Missing .env file. Copy .env.example to .env and configure: cp .env.example .env"
     else
-        echo "ERROR: Missing .env file. Create one with: EXTERNAL_IP=<your-external-ip>"
+        echo "ERROR: Missing .env file. Create one with: EXTERNAL_IP=<your-external-ip> and RSA_PUBLIC_KEY=<your-rsa-public-key>"
     fi
     exit 1
 fi
@@ -24,6 +24,11 @@ fi
 # Validate required variables
 if [[ -z "${EXTERNAL_IP}" ]]; then
     echo "ERROR: EXTERNAL_IP must be set in .env file"
+    exit 1
+fi
+
+if [[ -z "${RSA_PUBLIC_KEY}" ]]; then
+    echo "ERROR: RSA_PUBLIC_KEY must be set in .env file"
     exit 1
 fi
 

--- a/helm_charts/kafka/values.yaml
+++ b/helm_charts/kafka/values.yaml
@@ -1,0 +1,127 @@
+## Kafka's Java Heap size.
+heapOpts: -Xms256M -Xmx256M
+
+## Keep off unless performing a migration
+deleteTopicEnable: false
+
+# Replication - Single node setup
+replicaCount: 1
+defaultReplicationFactor: 1
+offsetsTopicReplicationFactor: 1
+## The replication factor for the transaction topic
+transactionStateLogReplicationFactor: 1
+## Overridden min.insync.replicas config for the transaction topic
+transactionStateLogMinIsr: 1
+
+persistence:
+    enabled: true
+    size: 2Gi
+
+zookeeper:
+  replicaCount: 1
+
+  heapSize: 256
+
+  persistence:
+    enabled: true
+    size: 1Gi
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+deleteTopicEnable: true
+
+service:
+  type: NodePort
+
+extraDeploy:
+  - |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: {{ include "kafka.name" . }}-connect
+      labels: {{- include "common.labels.standard" . | nindent 4 }}
+        app.kubernetes.io/component: connector
+    spec:
+      replicas: 1
+      selector:
+        matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+          app.kubernetes.io/component: connector
+      template:
+        metadata:
+          labels: {{- include "common.labels.standard" . | nindent 8 }}
+            app.kubernetes.io/component: connector
+        spec:
+          initContainers:
+            - name: plugins-downloader
+              image: busybox
+              imagePullPolicy: IfNotPresent
+              command: ["sh", "/tmp/kafka_plugin_downloader.sh"]
+              volumeMounts:
+                - name: kafka-connect-plugins-dir
+                  mountPath: /tmp
+                - name: plugin-downloader
+                  mountPath: /tmp/kafka_plugin_downloader.sh
+                  subPath: kafka_plugin_downloader.sh
+          containers:
+            - name: connect
+              image: debezium/connect:1.1
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: connector
+                  containerPort: 8083
+              volumeMounts:
+                - name: configuration
+                  mountPath: /bitnami/kafka/config
+              volumeMounts:
+                - name: kafka-connect-plugins-dir
+                  mountPath: /tmp  
+              env:
+              - name: BOOTSTRAP_SERVERS
+                value: "kafka:9092"
+              - name: GROUP_ID
+                value: "sde_group"
+              - name: CONFIG_STORAGE_TOPIC
+                value: "sde_storage_topic"
+              - name: OFFSET_STORAGE_TOPIC
+                value: "sde_offset_topic"
+              - name: KAFKA_CONNECT_PLUGINS_DIR
+                value: "/kafka/connect,/tmp"
+          volumes:
+            - name: configuration
+              configMap:
+                name: {{ include "kafka.name" . }}-connect
+            - name: kafka-connect-plugins-dir
+              emptyDir: {}
+            - name: plugin-downloader
+              configMap:
+                name: kafka-plugin-downloader
+                defaultMode: 0777
+
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "kafka.name" . }}-connect
+      labels: {{- include "common.labels.standard" . | nindent 4 }}
+        app.kubernetes.io/component: connector
+    data:
+      connect-standalone.properties: |-
+        bootstrap.servers = {{ include "kafka.name" . }}-0.{{ include "kafka.name" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.port }}
+  - |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ include "kafka.name" . }}-connect
+      labels: {{- include "common.labels.standard" . | nindent 4 }}
+        app.kubernetes.io/component: connector
+    spec:
+      ports:
+        - protocol: TCP
+          port: 8083
+          targetPort: connector
+      selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+        app.kubernetes.io/component: connector
+

--- a/helm_charts/pilot-hdc/metadata/values.yaml
+++ b/helm_charts/pilot-hdc/metadata/values.yaml
@@ -1,0 +1,75 @@
+appConfig:
+  port: 5066
+  env: staging
+  srv_namespace: metadata
+
+image:
+  repository: docker-registry.ebrains.eu/hdc-services-image/metadata
+  tag: 251
+  pullPolicy: IfNotPresent
+
+fullnameOverride: metadata
+container:
+  port: 5066
+
+service:
+  type: ClusterIP
+  port: 5066
+
+extraEnv:
+  DCM_PROJECT_ID: generate_id
+  RUN_MIGRATIONS: "true"
+  AUTH_HOST: "http://auth.utility:5061"
+  KAFKA_URL: "kafka.utility.svc.cluster.local:9092"
+  KAFKA_TOPIC: "metadata.items"
+extraEnvYaml:
+  - name: OPSDB_UTILITY_USERNAME
+    value: postgres
+  - name: OPSDB_UTILITY_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: postgres
+        key: postgres-password
+  - name: OPSDB_UTILITY_HOST
+    value: postgres.utility
+  - name: OPSDB_UTILITY_PORT
+    value: "5432"
+  - name: RSA_PUBLIC_KEY
+    valueFrom:
+      secretKeyRef:
+        name: rsa-public-key-secret
+        key: rsa-public-key
+
+resources:
+  limits:
+    cpu: "1"
+    memory: 500Mi
+  requests:
+    cpu: "10m"
+    memory: 50Mi
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  tcpSocket:
+    port: 5066
+
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /v1/health
+    port: 5066
+    scheme: HTTP
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 3
+
+replicaCount: 1
+
+updateStrategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 33%
+  type: RollingUpdate

--- a/helm_charts/postgres/values.yaml
+++ b/helm_charts/postgres/values.yaml
@@ -1,0 +1,35 @@
+# This vaule.yaml is for the postgres in utility namespace
+image:
+  registry: docker-registry.ebrains.eu
+  repository: hdc-services-external/postgresql
+
+global:
+  postgresql:
+    auth:
+      username: postgres
+      database: postgres
+
+fullnameOverride: postgres
+primary:
+  initdb:
+    scriptsConfigMap: "postgres-init-scripts"
+
+  extendedConfiguration: |
+        max_connections = 500
+        shared_buffers = 1500
+        cron.database_name = 'metadata'
+  resources:
+    limits:
+      cpu: 1
+      memory: 512Mi
+    requests:
+      cpu: "20m"
+      memory: 128Mi
+
+metrics:
+  enabled: false
+
+postgresqlSharedPreloadLibraries: "pgaudit,pg_cron"
+
+serviceAccount:
+  create: false

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -1,0 +1,36 @@
+# helm helm-vault-values.yml
+global:
+  enabled: true
+  tlsDisable: true
+
+server:
+  affinity: ""
+  
+  # Dev mode - no unsealing required, ready immediately
+  dev:
+    enabled: true
+    devRootToken: "root"
+  
+  # HA not needed in dev mode
+  ha:
+    enabled: false
+
+  service:
+    type: ClusterIP
+    
+  # Resource limits optimized for dev mode
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 50m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+
+injector:
+  enabled: false
+
+ui:
+  enabled: true
+  serviceType: ClusterIP
+  

--- a/terraform/run.sh
+++ b/terraform/run.sh
@@ -18,6 +18,7 @@ export TF_VAR_docker_registry_username="${DOCKER_REGISTRY_USERNAME:-}"
 export TF_VAR_docker_registry_password="${DOCKER_REGISTRY_PASSWORD:-}"
 export TF_VAR_docker_registry_external_username="${DOCKER_REGISTRY_EXTERNAL_USERNAME:-}"
 export TF_VAR_docker_registry_external_password="${DOCKER_REGISTRY_EXTERNAL_PASSWORD:-}"
+export TF_VAR_rsa_public_key="${RSA_PUBLIC_KEY:-}"
 
 # Check for auto-approve flag
 AUTO_APPROVE=false

--- a/terraform/utility.tf
+++ b/terraform/utility.tf
@@ -1,0 +1,179 @@
+resource "kubernetes_namespace" "utility" {
+  metadata {
+    name = "utility"
+  }
+}
+
+resource "kubernetes_secret" "docker_registry" {
+  metadata {
+    name      = "docker-registry-secret"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "docker-registry.ebrains.eu" = {
+          username = var.docker_registry_username
+          password = var.docker_registry_password
+          auth     = base64encode("${var.docker_registry_username}:${var.docker_registry_password}")
+        }
+      }
+    })
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+}
+
+resource "kubernetes_secret" "docker_registry_external" {
+  metadata {
+    name      = "docker-registry-external-secret"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "docker-registry.ebrains.eu" = {
+          username = var.docker_registry_external_username
+          password = var.docker_registry_external_password
+          auth     = base64encode("${var.docker_registry_external_username}:${var.docker_registry_external_password}")
+        }
+      }
+    })
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+}
+
+resource "kubernetes_secret" "rsa_public_key" {
+  metadata {
+    name      = "rsa-public-key-secret"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "rsa-public-key" = var.rsa_public_key
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+}
+
+resource "kubernetes_config_map" "postgres_init" {
+  metadata {
+    name      = "postgres-init-scripts"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  data = {
+    "my_init_script.sh" = file("../helm_charts/postgres/postgres-init.sql")
+  }
+}
+
+resource "helm_release" "metadata" {
+
+  name = "metadata-service"
+
+  repository = "https://pilotdataplatform.github.io/helm-charts/"
+  chart      = "metadata-service"
+  version    = var.metadata_chart_version
+  namespace  = kubernetes_namespace.utility.metadata[0].name
+  timeout    = "300"
+
+  values = [file("../helm_charts/pilot-hdc/metadata/values.yaml")]
+
+  set {
+    name  = "image.tag"
+    value = var.metadata_app_version
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "imagePullSecrets[0].name"
+    value = kubernetes_secret.docker_registry.metadata[0].name
+  }
+
+  depends_on = [
+    helm_release.postgres,
+    kubernetes_secret.rsa_public_key
+  ]
+}
+
+
+resource "helm_release" "postgres" {
+
+  name = "postgres"
+
+  repository = "https://pilotdataplatform.github.io/helm-charts/"
+  chart      = "postgresql"
+  namespace  = kubernetes_namespace.utility.metadata[0].name
+  version    = var.postgres_chart_version
+  timeout    = "300"
+
+  values = [file("../helm_charts/postgres/values.yaml")]
+
+  set {
+    name  = "image.tag"
+    value = var.postgres_app_version
+  }
+
+  set {
+    name  = "global.imagePullSecrets[0]"
+    value = kubernetes_secret.docker_registry_external.metadata[0].name
+  }
+
+  depends_on = [
+    kubernetes_config_map.postgres_init
+  ]
+}
+
+resource "helm_release" "kafka" {
+
+  name = "kafka"
+
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "kafka"
+  namespace  = kubernetes_namespace.utility.metadata[0].name
+  timeout    = "300"
+  # according to this issue we should set the wait to false https://github.com/hashicorp/terraform-provider-helm/issues/683
+  wait    = "false"
+  version = var.kafka_chart_version
+
+  values = [file("../helm_charts/kafka/values.yaml")]
+  depends_on = [
+    kubernetes_manifest.configmap_utility_kafka_plugin_downloader
+  ]
+
+}
+
+resource "kubernetes_manifest" "configmap_utility_kafka_plugin_downloader" {
+  manifest = {
+    "apiVersion" = "v1"
+    "data" = {
+      "kafka_plugin_downloader.sh" = <<-EOT
+      #!/bin/sh \n cd /tmp \n wget https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-jdbc/versions/10.3.3/confluentinc-kafka-connect-jdbc-10.3.3.zip \n wget  https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-elasticsearch/versions/11.1.8/confluentinc-kafka-connect-elasticsearch-11.1.8.zip \n unzip confluentinc-kafka-connect-jdbc-10.3.3.zip \n unzip confluentinc-kafka-connect-elasticsearch-11.1.8.zip \n rm confluentinc-kafka-connect-jdbc-10.3.3.zip \n rm confluentinc-kafka-connect-elasticsearch-11.1.8.zip \n
+      EOT
+    }
+    "kind" = "ConfigMap"
+    "metadata" = {
+      "name"      = "kafka-plugin-downloader"
+      "namespace" = "utility"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,3 +29,74 @@ variable "minio_chart_version" {
   default = "11.10.26"
 }
 
+variable "metadata_chart_version" {
+  type    = string
+  default = "0.5.1"
+}
+
+variable "metadata_app_version" {
+  type    = string
+  default = "2.2.9"
+}
+
+variable "docker_registry_username" {
+  type        = string
+  description = "Username for docker-registry.ebrains.eu"
+  default     = ""
+  sensitive   = true
+}
+
+variable "docker_registry_password" {
+  type        = string
+  description = "Password for docker-registry.ebrains.eu"
+  default     = ""
+  sensitive   = true
+}
+
+variable "postgres_chart_version" {
+  type    = string
+  default = "15.5.17"
+}
+
+variable "postgres_app_version" {
+  type    = string
+  default = "16.3.0-932ab18-pgcron"
+}
+
+variable "kafka_chart_version" {
+  type    = string
+  default = "20.0.3"
+}
+
+variable "docker_registry_external_username" {
+  type        = string
+  description = "Username for docker-registry.ebrains.eu hdc-services-external project"
+  default     = ""
+  sensitive   = true
+}
+
+variable "docker_registry_external_password" {
+  type        = string
+  description = "Password for docker-registry.ebrains.eu hdc-services-external project"
+  default     = ""
+  sensitive   = true
+}
+
+variable "debug_mode" {
+  type        = bool
+  description = "Enable debug mode - exposes internal services (like Vault) externally. WARNING: Only use for development!"
+  default     = false
+}
+
+variable "deploy_vault" {
+  type        = bool
+  description = "Deploy Vault service. Set to false to disable vault deployment (default for alpha)"
+  default     = false
+}
+
+variable "rsa_public_key" {
+  type        = string
+  description = "RSA public key for metadata service authentication"
+  default     = ""
+  sensitive   = true
+}

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -1,0 +1,64 @@
+# Create namespace first
+resource "kubernetes_namespace" "vault" {
+  count = var.deploy_vault ? 1 : 0
+  metadata {
+    name = "vault"
+  }
+}
+
+resource "helm_release" "vault" {
+  count = var.deploy_vault ? 1 : 0
+  name  = "vault"
+
+  repository       = "https://helm.releases.hashicorp.com"
+  chart            = "vault"
+  namespace        = kubernetes_namespace.vault[0].metadata[0].name
+  create_namespace = false
+  timeout          = 300
+
+  values = [file("../helm_charts/vault/values.yaml")]
+
+  depends_on = [helm_release.cert-manager, kubernetes_namespace.vault]
+}
+
+# Vault Ingress for external access (only in debug mode for security)
+resource "kubernetes_ingress_v1" "vault" {
+  count = var.deploy_vault && var.debug_mode ? 1 : 0
+  metadata {
+    name      = "vault"
+    namespace = kubernetes_namespace.vault[0].metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.class"              = "traefik"
+      "cert-manager.io/cluster-issuer"           = "selfsigned-issuer"
+      "traefik.ingress.kubernetes.io/router.tls" = "true"
+    }
+  }
+
+  spec {
+    tls {
+      hosts       = ["vault.${local.node_ip}.nip.io"]
+      secret_name = "vault-tls"
+    }
+
+    rule {
+      host = "vault.${local.node_ip}.nip.io"
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "vault"
+              port {
+                number = 8200
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.vault]
+}
+


### PR DESCRIPTION
In this commit we are adding the first pilot-hdc service: `metadata`. It requires `kafka` and `postgres`, so we are adding those services too.

The `postgres` init script should be placed in
`helm_charts/postgres/postgres-init.sql`. It is git ignored due to security concerns.

A previous version of `metadata` required vaul too, so we added it. But we then pushed a new version of the `metadata` service that does NOT require vault and made the vault deployment optional.

We might remove it if it's not needed once we have all services running.