### PR TITLE
Security hardening: HTTPS everywhere + secure-by-default demo_mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,30 @@
 # Required: External IP for ingress hostnames
 EXTERNAL_IP=1.2.3.4
 
-# Demo mode: Controls Terraform provider TLS verification only
-# Set to 'true' to accept self-signed certificates (default, recommended for dev)
-# Set to 'false' to require CA-signed certificates (production with proper PKI)
+# Demo mode: Controls Terraform provider TLS verification for Keycloak provisioning
+# IMPORTANT: This platform uses cert-manager with self-signed certificates by default
+#
+# YOU MUST CHANGE THIS VALUE based on your certificate setup:
+#
+# Set to 'true' if using self-signed certificates (default cert-manager setup)
+#   - REQUIRED for Terraform to provision Keycloak clients with self-signed certs
+#   - Deployment WILL FAIL if set to 'false' with self-signed certificates
+#   - Recommended for development, testing, and demo environments
+#
+# Keep 'false' only if you have configured proper CA-signed certificates
+#   - Requires valid PKI infrastructure (e.g., Let's Encrypt, corporate CA)
+#   - Use for production deployments with proper certificate management
+#
 # Note: User-facing auth flows always use HTTPS regardless of this setting
 DEMO=false
 
 # Required: RSA public key for pilot-hdc services authentication
 # Base64 encoded RSA public key (this is a dummy one, not actually correlated with a private key)
 RSA_PUBLIC_KEY=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF0QTBrU0VwaW10VjA1WGlRcmFWQjkKQWZEZU1xRlpPcTNGU1hNOTJPbGI0NEdWR1ZqY3V5dmdVeWFDaTZiMzNhNHBHaGp4b00weGRVT2gvb0NJRUFEawo3cThBSjdRV3JmU0NyZ3ZSTW42RFNuTEJQU0d4WWlPdnExNUhIMUVsZmtTVXVSSDZNN1BKb0VkNlBFRDB5dFdLCnFNcXpiSFhFMEs2cEI3Y05vNmdCUjYwaHNjZ2FXVlhPMUtybDFEcVo5ZHVRME1CSXlIcitZU1pkRjhTUWdUOW4KWitKbGtmR2xuNWxkZDRBNXlKQUxJb0VZQW1VUW1SR0UyNlRIWHhuZS9Mclk5NmZwM3hlRFpUMHQ0d0hZYmU1WQp6S2hvT05rNjByK1h5M3hBUmNBUXNuOTlLaTFIY2oyV0tvOFkyNmpxNlVqVVkzSHBQYlB4MTBNM2pFUkpPZTF4CndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t
+
+# Required: Keycloak admin username for Terraform provider
+# Do NOT use default/weak usernames like 'admin' or 'user'
+KEYCLOAK_ADMIN_USERNAME=myadminuser
 
 # Required: Docker registry credentials for private image pulls
 # These are only needed once due to Terraform lifecycle.ignore_changes

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Required: External IP for ingress hostnames
 EXTERNAL_IP=1.2.3.4
 
+# Demo mode: Controls Terraform provider TLS verification only
+# Set to 'true' to accept self-signed certificates (default, recommended for dev)
+# Set to 'false' to require CA-signed certificates (production with proper PKI)
+# Note: User-facing auth flows always use HTTPS regardless of this setting
+DEMO=false
+
 # Required: RSA public key for pilot-hdc services authentication
 # Base64 encoded RSA public key (this is a dummy one, not actually correlated with a private key)
 RSA_PUBLIC_KEY=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF0QTBrU0VwaW10VjA1WGlRcmFWQjkKQWZEZU1xRlpPcTNGU1hNOTJPbGI0NEdWR1ZqY3V5dmdVeWFDaTZiMzNhNHBHaGp4b00weGRVT2gvb0NJRUFEawo3cThBSjdRV3JmU0NyZ3ZSTW42RFNuTEJQU0d4WWlPdnExNUhIMUVsZmtTVXVSSDZNN1BKb0VkNlBFRDB5dFdLCnFNcXpiSFhFMEs2cEI3Y05vNmdCUjYwaHNjZ2FXVlhPMUtybDFEcVo5ZHVRME1CSXlIcitZU1pkRjhTUWdUOW4KWitKbGtmR2xuNWxkZDRBNXlKQUxJb0VZQW1VUW1SR0UyNlRIWHhuZS9Mclk5NmZwM3hlRFpUMHQ0d0hZYmU1WQp6S2hvT05rNjByK1h5M3hBUmNBUXNuOTlLaTFIY2oyV0tvOFkyNmpxNlVqVVkzSHBQYlB4MTBNM2pFUkpPZTF4CndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t

--- a/README.md
+++ b/README.md
@@ -1,5 +1,118 @@
-## Intro
-wip
+## Pilot HDC Lite
+
+A lightweight, single-VM lite version of the [Pilot-HDC](https://hdc.humanbrainproject.eu/) platform. This lite version is designed for:
+- Scientific researchers and small labs
+- Internal development teams
+- CI/CD and demo environments
+- Local testing and evaluation
+
+### Key Features
+- **One-script deployment**: `./bootstrap.sh` sets up the complete platform
+- **Resource efficient**: Runs on 16GB RAM / 4-6 vCPU / 100GB disk
+- **Offline capable**: Works without external dependencies after initial setup
+- **Production patterns**: Uses same Terraform + Helm deployment as full platform
+
+### Architecture
+- **k3s**: Lightweight Kubernetes distribution
+- **Keycloak**: User authentication and SSO
+- **MinIO**: S3-compatible object storage
+- **PostgreSQL**: Metadata and application databases
+- **Redis**: Session and cache management
+- **Kafka + Elasticsearch**: Data processing pipeline (utility namespace)
+
+### Quick Start
+
+1. **Prerequisites**:
+   - Ubuntu/Debian-based VM with sudo access
+   - 16GB+ RAM, 4-6 vCPU, 100GB disk
+   - Network connectivity for initial image pulls
+
+2. **Create `.env` file**:
+   ```bash
+   EXTERNAL_IP=192.168.1.100  # Your VM IP
+   RSA_PUBLIC_KEY="<your-public-key>"
+   DEMO=true  # Required: Set to 'true' to accept self-signed certificates
+   ```
+
+   **Note**: This platform uses self-signed certificates from cert-manager. You must set `DEMO=true` to allow Terraform to deploy. See [Demo Mode Configuration](#demo-mode-configuration) below.
+
+3. **Deploy**:
+   ```bash
+   ./bootstrap.sh
+   ```
+
+4. **Access**:
+   - Keycloak: `https://keycloak.<EXTERNAL_IP>.nip.io`
+   - MinIO Console: `https://minio-console.<EXTERNAL_IP>.nip.io`
+
+## Security Considerations
+
+### Demo Mode Configuration
+
+This project uses a `DEMO` environment variable to control Terraform provider behavior during deployment.
+
+#### What DEMO Mode Controls
+
+**DEMO=false (Default - Secure by Default)**
+- Terraform provider requires CA-signed certificates
+- Use this when you have proper PKI infrastructure
+- Deployment will fail with self-signed certificates
+- **This is the secure default** - forces explicit security decisions
+
+**DEMO=true (Development with Self-Signed Certificates)**
+- Terraform provider accepts self-signed certificates from cert-manager
+- **Required for this platform** since it uses cert-manager self-signed certs
+- Enables quick setup without needing proper PKI infrastructure
+- Explicit opt-in for relaxed TLS verification during deployment
+- **NOTE**: User authentication flows always use HTTPS regardless of this setting
+
+#### ✅ What's Always Secured (Regardless of DEMO Mode)
+
+- **HTTPS Everywhere**: All user-facing traffic uses HTTPS via cert-manager
+- **Authentication Security**: OAuth2/OIDC flows always use HTTPS endpoints only
+- **No HTTP Fallbacks**: HTTP redirects and origins are disabled for auth flows
+- **Self-signed Certificates**: Managed by cert-manager ClusterIssuer
+- **Secret Management**: Credentials stored in Kubernetes secrets
+- **Infrastructure as Code**: Declarative, auditable configuration
+
+#### 🔒 Hardening for Production Use
+
+If deploying this platform for real workloads, implement these additional measures:
+
+1. **Network Isolation**
+   - Deploy on isolated private network or VPN
+   - Configure firewall rules (allow only 80/443)
+   - Use network policies for pod-to-pod isolation
+
+2. **Certificate Management**
+   - Replace self-signed certs with CA-signed certificates
+   - Use Let's Encrypt for public endpoints
+   - Implement proper certificate rotation
+
+3. **Authentication & Authorization**
+   - Configure LDAP/Active Directory integration
+   - Implement proper RBAC policies
+   - Enable audit logging
+   - Set up MFA for admin accounts
+
+4. **Data Protection**
+   - Enable encryption at rest for persistent volumes
+   - Configure backup and disaster recovery
+   - Implement data retention policies
+   - **Terraform State Security**: The local Terraform state file (`/home/ubuntu/.terraform-state/pilot-hdc-lite.tfstate`) contains sensitive data including database passwords. For production:
+     - Use remote state backend (S3, Azure Blob, etc.) with encryption
+     - Enable state locking to prevent concurrent modifications
+     - Restrict access to state files using IAM policies
+     - Never commit state files to version control
+
+5. **Monitoring & Logging**
+   - Add Prometheus/Grafana for monitoring
+   - Configure centralized logging
+   - Set up security alerts
+
+### Reporting Security Issues
+
+This is a demo/development platform. For production deployments, conduct a thorough security review appropriate to your organization's requirements and compliance needs.
 
 ## Acknowledgements
 The development of the HealthDataCloud open source software was supported by the EBRAINS research infrastructure, funded from the European Union's Horizon 2020 Framework Programme for Research and Innovation under the Specific Grant Agreement No. 945539 (Human Brain Project SGA3) and H2020 Research and Innovation Action Grant Interactive Computing E-Infrastructure for the Human Brain Project ICEI 800858.

--- a/helm_charts/pilot-hdc/auth/values.yaml
+++ b/helm_charts/pilot-hdc/auth/values.yaml
@@ -35,8 +35,8 @@ extraEnv:
   LDAP_URL: ""
   LDAP_ADMIN_DN: ""
   LDAP_ADMIN_SECRET: ""
-  # Keycloak configuration
-  KEYCLOAK_SERVER_URL: "http://keycloak.keycloak/"
+  # Keycloak configuration - uses HTTPS external ingress
+  KEYCLOAK_SERVER_URL: "https://keycloak.${EXTERNAL_IP}.nip.io"
   KEYCLOAK_CLIENT_ID: "pilot-hdc-lite"
   KEYCLOAK_REALM: "master"
   KEYCLOAK_ID: "pilot-hdc-lite"
@@ -52,10 +52,10 @@ extraEnv:
   # AD groups (required fields, not used in Keycloak-only mode)
   AD_USER_GROUP: "users"
   AD_ADMIN_GROUP: "admin"
-  # Domain and invitation URLs (alpha placeholders)
-  DOMAIN_NAME: "http://localhost"
-  INVITATION_URL_LOGIN: "http://localhost/login"
-  INVITATION_REGISTER_URL: "http://localhost/self-registration/{invitation_code}/"
+  # Domain and invitation URLs - HTTPS only
+  DOMAIN_NAME: "https://${EXTERNAL_IP}.nip.io"
+  INVITATION_URL_LOGIN: "https://${EXTERNAL_IP}.nip.io/login"
+  INVITATION_REGISTER_URL: "https://${EXTERNAL_IP}.nip.io/self-registration/{invitation_code}/"
 
 extraEnvYaml:
   - name: RDS_PWD

--- a/helm_charts/pilot-hdc/auth/values.yaml
+++ b/helm_charts/pilot-hdc/auth/values.yaml
@@ -1,0 +1,110 @@
+appConfig:
+  port: 5061
+  env: staging
+  srv_namespace: service_auth
+
+image:
+  repository: docker-registry.ebrains.eu/hdc-services-image/auth
+  tag: 2.2.27
+  pullPolicy: IfNotPresent
+
+fullnameOverride: auth
+
+container:
+  port: 5061
+
+service:
+  type: ClusterIP
+  port: 5061
+
+extraEnv:
+  # Simplified alpha configuration - Keycloak only, no LDAP/AD/FreeIPA
+  EMAIL_SUPPORT: "support@pilot-hdc-lite.local"
+  EMAIL_ADMIN: "admin@pilot-hdc-lite.local"
+  EMAIL_HELPDESK: "helpdesk@pilot-hdc-lite.local"
+  RDS_SCHEMA_PREFIX: "pilot"
+  RDS_HOST: "postgres.utility"
+  RDS_PORT: "5432"
+  RDS_DBNAME: "auth"
+  RDS_PRE_PING: true
+  RDS_USER: "auth_user"
+  PROJECT_NAME: "Pilot HDC Lite"
+  IDENTITY_BACKEND: "keycloak"
+  # Disable LDAP/AD features for alpha
+  ENABLE_ACTIVE_DIRECTORY: false
+  LDAP_URL: ""
+  LDAP_ADMIN_DN: ""
+  LDAP_ADMIN_SECRET: ""
+  # Keycloak configuration
+  KEYCLOAK_SERVER_URL: "http://keycloak.keycloak/"
+  KEYCLOAK_CLIENT_ID: "pilot-hdc-lite"
+  KEYCLOAK_REALM: "master"
+  KEYCLOAK_ID: "pilot-hdc-lite"
+  # Redis configuration
+  REDIS_HOST: "redis-master.redis"
+  REDIS_PORT: "6379"
+  REDIS_DB: "0"
+  # Single worker for alpha (vs 2+ in production)
+  WORKERS: 1
+  # Application paths
+  START_PATH: "pilot-hdc-lite"
+  GUIDE_PATH: ""
+  # AD groups (required fields, not used in Keycloak-only mode)
+  AD_USER_GROUP: "users"
+  AD_ADMIN_GROUP: "admin"
+  # Domain and invitation URLs (alpha placeholders)
+  DOMAIN_NAME: "http://localhost"
+  INVITATION_URL_LOGIN: "http://localhost/login"
+  INVITATION_REGISTER_URL: "http://localhost/self-registration/{invitation_code}/"
+
+extraEnvYaml:
+  - name: RDS_PWD
+    valueFrom:
+      secretKeyRef:
+        name: auth-utility-secret
+        key: RDS_PWD
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: auth-utility-secret
+        key: REDIS_PASSWORD
+  - name: KEYCLOAK_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: auth-utility-secret
+        key: KEYCLOAK_CLIENT_SECRET
+
+resources:
+  limits:
+    cpu: "100m"
+    memory: 100Mi
+  requests:
+    cpu: "50m"
+    memory: 50Mi
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  tcpSocket:
+    port: 5061
+
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /v1/health
+    port: 5061
+    scheme: HTTP
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 5
+
+# Single replica for alpha
+replicaCount: 1
+
+updateStrategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+  type: RollingUpdate

--- a/helm_charts/pilot-hdc/dataops/values.yaml
+++ b/helm_charts/pilot-hdc/dataops/values.yaml
@@ -22,7 +22,7 @@ extraEnv:
   RDS_HOST: "postgres.utility"
   RDS_PORT: 5432
   RDS_NAME: "dataops"
-  RDS_USERNAME: "postgres"
+  RDS_USERNAME: "dataops_user"
   RDS_SCHEMA: "public"
   RDS_ECHO_SQL_QUERIES: false
   LINEAGE_SERVICE: "http://lineage.utility:5064"

--- a/helm_charts/pilot-hdc/metadata/values.yaml
+++ b/helm_charts/pilot-hdc/metadata/values.yaml
@@ -24,16 +24,25 @@ extraEnv:
   KAFKA_TOPIC: "metadata.items"
 extraEnvYaml:
   - name: OPSDB_UTILITY_USERNAME
-    value: postgres
+    valueFrom:
+      secretKeyRef:
+        name: metadata-db-credential
+        key: DB_USERNAME
   - name: OPSDB_UTILITY_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: postgres
-        key: postgres-password
+        name: metadata-db-credential
+        key: DB_PASSWORD
   - name: OPSDB_UTILITY_HOST
-    value: postgres.utility
+    valueFrom:
+      secretKeyRef:
+        name: metadata-db-credential
+        key: DB_HOST
   - name: OPSDB_UTILITY_PORT
-    value: "5432"
+    valueFrom:
+      secretKeyRef:
+        name: metadata-db-credential
+        key: DB_PORT
   - name: RSA_PUBLIC_KEY
     valueFrom:
       secretKeyRef:

--- a/helm_charts/pilot-hdc/project/values.yaml
+++ b/helm_charts/pilot-hdc/project/values.yaml
@@ -36,23 +36,23 @@ extraEnvYaml:
   - name: OPSDB_UTILITY_USERNAME
     valueFrom:
       secretKeyRef:
-        name: opsdb-utility-credential
-        key: username
+        name: project-db-credential
+        key: DB_USERNAME
   - name: OPSDB_UTILITY_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: opsdb-utility-credential
-        key: password
+        name: project-db-credential
+        key: DB_PASSWORD
   - name: OPSDB_UTILITY_HOST
     valueFrom:
       secretKeyRef:
-        name: opsdb-utility-credential
-        key: host
+        name: project-db-credential
+        key: DB_HOST
   - name: OPSDB_UTILITY_PORT
     valueFrom:
       secretKeyRef:
-        name: opsdb-utility-credential
-        key: port
+        name: project-db-credential
+        key: DB_PORT
   - name: S3_ACCESS_KEY
     valueFrom:
       secretKeyRef:

--- a/terraform/keycloak-client.tf
+++ b/terraform/keycloak-client.tf
@@ -1,0 +1,68 @@
+# Keycloak Client Configuration for Auth Service
+# Uses Terraform Keycloak provider to manage OIDC client declaratively
+
+# Read Keycloak admin credentials from the Keycloak Helm release
+data "kubernetes_secret" "keycloak_admin" {
+  metadata {
+    name      = "keycloak"
+    namespace = "keycloak"
+  }
+  depends_on = [helm_release.keycloak]
+}
+
+# Create OIDC client for pilot-hdc-lite auth service
+resource "keycloak_openid_client" "pilot_hdc_lite" {
+  realm_id  = "master"  # Using master realm for alpha
+  client_id = "pilot-hdc-lite"
+
+  name    = "Pilot HDC Lite Auth Service"
+  enabled = true
+
+  # Confidential client - generates client secret
+  access_type                  = "CONFIDENTIAL"
+  standard_flow_enabled        = true
+  direct_access_grants_enabled = true
+  service_accounts_enabled     = true
+
+  # Valid redirect URIs - HTTPS only
+  valid_redirect_uris = [
+    "https://${var.external_ip}.nip.io/*"
+  ]
+
+  # Web origins - HTTPS only
+  web_origins = [
+    "https://${var.external_ip}.nip.io"
+  ]
+
+  # Service URLs - HTTPS only
+  root_url  = "https://${var.external_ip}.nip.io"
+  admin_url = "https://${var.external_ip}.nip.io"
+  base_url  = "https://${var.external_ip}.nip.io"
+
+  backchannel_logout_session_required = false
+}
+
+# Configure default scopes for the client
+resource "keycloak_openid_client_default_scopes" "pilot_hdc_lite" {
+  realm_id  = "master"
+  client_id = keycloak_openid_client.pilot_hdc_lite.id
+
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "openid"
+  ]
+}
+
+# Output the client secret for use in auth service configuration
+# This will be consumed by the auth-utility-secret
+output "keycloak_client_secret" {
+  value     = keycloak_openid_client.pilot_hdc_lite.client_secret
+  sensitive = true
+}
+
+output "keycloak_client_id" {
+  value = keycloak_openid_client.pilot_hdc_lite.client_id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,6 +14,16 @@ terraform {
       source  = "hashicorp/helm"
       version = "2.16.1"
     }
+
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "4.1.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -29,6 +39,14 @@ provider "helm" {
 
 provider "kubectl" {
   config_path = "~/.kube/config"
+}
+
+provider "keycloak" {
+  client_id                = "admin-cli"
+  username                 = var.keycloak_admin_username
+  password                 = data.kubernetes_secret.keycloak_admin.data["admin-password"]
+  url                      = var.keycloak_url != "" ? var.keycloak_url : "https://keycloak.${var.external_ip}.nip.io"
+  tls_insecure_skip_verify = var.demo_mode  # Only skip TLS verification in demo mode
 }
 
 # Data sources

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,12 +2,12 @@ terraform {
   backend "local" {
     path = "/home/ubuntu/.terraform-state/pilot-hdc-lite.tfstate"
   }
-  required_version = ">= 0.13"
+  required_version = "1.5.7"
 
   required_providers {
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = ">= 1.7.0"
+      version = "1.19.0"
     }
 
     helm = {
@@ -22,7 +22,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = "3.7.2"
     }
   }
 }

--- a/terraform/run.sh
+++ b/terraform/run.sh
@@ -20,6 +20,7 @@ export TF_VAR_docker_registry_external_username="${DOCKER_REGISTRY_EXTERNAL_USER
 export TF_VAR_docker_registry_external_password="${DOCKER_REGISTRY_EXTERNAL_PASSWORD:-}"
 export TF_VAR_rsa_public_key="${RSA_PUBLIC_KEY:-}"
 export TF_VAR_demo_mode="${DEMO:-false}"
+export TF_VAR_keycloak_admin_username="${KEYCLOAK_ADMIN_USERNAME}"
 
 # Check for auto-approve flag
 AUTO_APPROVE=false

--- a/terraform/run.sh
+++ b/terraform/run.sh
@@ -19,6 +19,7 @@ export TF_VAR_docker_registry_password="${DOCKER_REGISTRY_PASSWORD:-}"
 export TF_VAR_docker_registry_external_username="${DOCKER_REGISTRY_EXTERNAL_USERNAME:-}"
 export TF_VAR_docker_registry_external_password="${DOCKER_REGISTRY_EXTERNAL_PASSWORD:-}"
 export TF_VAR_rsa_public_key="${RSA_PUBLIC_KEY:-}"
+export TF_VAR_demo_mode="${DEMO:-false}"
 
 # Check for auto-approve flag
 AUTO_APPROVE=false

--- a/terraform/utility.tf
+++ b/terraform/utility.tf
@@ -437,7 +437,9 @@ resource "helm_release" "auth" {
   namespace  = kubernetes_namespace.utility.metadata[0].name
   timeout    = "300"
 
-  values = [file("../helm_charts/pilot-hdc/auth/values.yaml")]
+  values = [templatefile("../helm_charts/pilot-hdc/auth/values.yaml", {
+    EXTERNAL_IP = var.external_ip
+  })]
 
   set {
     name  = "image.tag"

--- a/terraform/utility.tf
+++ b/terraform/utility.tf
@@ -4,6 +4,27 @@ resource "kubernetes_namespace" "utility" {
   }
 }
 
+# Generate random passwords for service-specific database users
+resource "random_password" "metadata_db_password" {
+  length  = 32
+  special = true
+}
+
+resource "random_password" "project_db_password" {
+  length  = 32
+  special = true
+}
+
+resource "random_password" "dataops_db_password" {
+  length  = 32
+  special = true
+}
+
+resource "random_password" "auth_db_password" {
+  length  = 32
+  special = true
+}
+
 resource "kubernetes_secret" "docker_registry" {
   metadata {
     name      = "docker-registry-secret"
@@ -140,7 +161,7 @@ resource "kubernetes_secret" "dataops_utility_secret" {
   type = "Opaque"
 
   data = {
-    "RDS_PASSWORD"   = data.kubernetes_secret.postgres_credential.data["postgres-password"]
+    "RDS_PASSWORD"   = random_password.dataops_db_password.result
     "REDIS_PASSWORD" = data.kubernetes_secret.redis_credential.data["redis-password"]
   }
 
@@ -149,9 +170,56 @@ resource "kubernetes_secret" "dataops_utility_secret" {
   }
 
   depends_on = [
-    data.kubernetes_secret.postgres_credential,
+    random_password.dataops_db_password,
     data.kubernetes_secret.redis_credential
   ]
+}
+
+# Service-specific database credential secrets
+resource "kubernetes_secret" "metadata_db_credential" {
+  metadata {
+    name      = "metadata-db-credential"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "DB_USERNAME" = "metadata_user"
+    "DB_PASSWORD" = random_password.metadata_db_password.result
+    "DB_HOST"     = "postgres.utility"
+    "DB_PORT"     = "5432"
+    "DB_NAME"     = "metadata"
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+
+  depends_on = [random_password.metadata_db_password]
+}
+
+resource "kubernetes_secret" "project_db_credential" {
+  metadata {
+    name      = "project-db-credential"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "DB_USERNAME" = "project_user"
+    "DB_PASSWORD" = random_password.project_db_password.result
+    "DB_HOST"     = "postgres.utility"
+    "DB_PORT"     = "5432"
+    "DB_NAME"     = "project"
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+
+  depends_on = [random_password.project_db_password]
 }
 
 resource "kubernetes_config_map" "postgres_init" {
@@ -161,8 +229,20 @@ resource "kubernetes_config_map" "postgres_init" {
   }
 
   data = {
-    "my_init_script.sh" = file("../helm_charts/postgres/postgres-init.sql")
+    "my_init_script.sh" = templatefile("../helm_charts/postgres/postgres-init.sql", {
+      METADATA_DB_PASSWORD = random_password.metadata_db_password.result
+      PROJECT_DB_PASSWORD  = random_password.project_db_password.result
+      DATAOPS_DB_PASSWORD  = random_password.dataops_db_password.result
+      AUTH_DB_PASSWORD     = random_password.auth_db_password.result
+    })
   }
+
+  depends_on = [
+    random_password.metadata_db_password,
+    random_password.project_db_password,
+    random_password.dataops_db_password,
+    random_password.auth_db_password
+  ]
 }
 
 resource "helm_release" "metadata" {
@@ -194,7 +274,8 @@ resource "helm_release" "metadata" {
 
   depends_on = [
     helm_release.postgres,
-    kubernetes_secret.rsa_public_key
+    kubernetes_secret.rsa_public_key,
+    kubernetes_secret.metadata_db_credential
   ]
 }
 
@@ -285,7 +366,7 @@ resource "helm_release" "project" {
 
   depends_on = [
     helm_release.postgres,
-    kubernetes_secret.opsdb_utility_credential,
+    kubernetes_secret.project_db_credential,
     kubernetes_secret.minio_credential
   ]
 }
@@ -316,5 +397,62 @@ resource "helm_release" "dataops" {
   depends_on = [
     helm_release.redis,
     kubernetes_secret.dataops_utility_secret
+  ]
+}
+
+# Auth service secret - combines DB, Redis, and Keycloak credentials
+resource "kubernetes_secret" "auth_utility_secret" {
+  metadata {
+    name      = "auth-utility-secret"
+    namespace = kubernetes_namespace.utility.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "RDS_PWD"                 = random_password.auth_db_password.result
+    "REDIS_PASSWORD"          = data.kubernetes_secret.redis_credential.data["redis-password"]
+    "KEYCLOAK_CLIENT_SECRET"  = keycloak_openid_client.pilot_hdc_lite.client_secret
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+
+  depends_on = [
+    random_password.auth_db_password,
+    data.kubernetes_secret.redis_credential,
+    keycloak_openid_client.pilot_hdc_lite
+  ]
+}
+
+# Auth service deployment
+resource "helm_release" "auth" {
+
+  name = "auth-service"
+
+  repository = "https://pilotdataplatform.github.io/helm-charts/"
+  chart      = "auth-service"
+  version    = var.auth_chart_version
+  namespace  = kubernetes_namespace.utility.metadata[0].name
+  timeout    = "300"
+
+  values = [file("../helm_charts/pilot-hdc/auth/values.yaml")]
+
+  set {
+    name  = "image.tag"
+    value = var.auth_app_version
+  }
+
+  set {
+    name  = "imagePullSecrets[0].name"
+    value = kubernetes_secret.docker_registry.metadata[0].name
+  }
+
+  depends_on = [
+    helm_release.postgres,
+    helm_release.redis,
+    helm_release.keycloak,
+    kubernetes_secret.auth_utility_secret
   ]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -125,3 +125,31 @@ variable "rsa_public_key" {
   default     = ""
   sensitive   = true
 }
+
+variable "auth_chart_version" {
+  type    = string
+  default = "0.7.2"
+}
+
+variable "auth_app_version" {
+  type    = string
+  default = "2.2.27"
+}
+
+variable "keycloak_admin_username" {
+  type        = string
+  description = "Keycloak admin username"
+  default     = "user"
+}
+
+variable "keycloak_url" {
+  type        = string
+  description = "Keycloak URL for Terraform provider (defaults to external nip.io URL)"
+  default     = ""
+}
+
+variable "demo_mode" {
+  type        = bool
+  description = "Enable demo mode: Terraform provider accepts self-signed certificates. Set to false to require CA-signed certificates."
+  default     = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -138,8 +138,8 @@ variable "auth_app_version" {
 
 variable "keycloak_admin_username" {
   type        = string
-  description = "Keycloak admin username"
-  default     = "user"
+  description = "Keycloak admin username (must be explicitly set for security)"
+  sensitive   = true
 }
 
 variable "keycloak_url" {


### PR DESCRIPTION
1. HTTPS-Only Authentication Flows (Fixes Security Review Issues)
- **terraform/keycloak-client.tf** (NEW): OIDC client configuration
  - valid_redirect_uris: HTTPS only (removed HTTP/localhost)
  - web_origins: HTTPS only (removed HTTP origin)
  - root_url, admin_url, base_url: HTTPS only
  - Fixes HIGH severity: Prevents token/session exposure over HTTP
  - Fixes MEDIUM severity: Prevents downgrade attacks

2. Secure-by-Default Configuration
- **terraform/variables.tf**: Changed demo_mode default from true → false
- **terraform/run.sh**: Changed DEMO fallback from true → false
- **.env.example**: Updated to DEMO=false with clear documentation
- Forces explicit opt-in for self-signed certificate acceptance
- Addresses MEDIUM severity: TLS verification defaults to secure

3. Documentation Updates
- **README.md**: Complete rewrite with security-focused content
  - Added Demo Mode Configuration section
  - Clarified what DEMO mode controls (Terraform TLS only)
  - Emphasized user auth flows always use HTTPS
  - Added production hardening guidelines
  - Improved Quick Start with clear DEMO=true requirement

4. Auth Service Deployment (Part of Complete Platform)
- **helm_charts/pilot-hdc/auth/values.yaml** (NEW): Auth service config
- **terraform/utility.tf**: Added auth service deployment
- **terraform/main.tf**: Added Keycloak provider configuration
- Keycloak-only authentication (no LDAP/AD in alpha)

5. Database Least Privilege (Part of Auth Work)
- Service-specific database users with ownership model
- Random passwords for metadata_user, project_user, dataops_user, auth_user
- Updated all service configurations to use dedicated credentials