### PR TITLE
IEBH-457: Deploy portal with Keycloak HDC realm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,19 @@ DEMO=false
 # Base64 encoded RSA public key (this is a dummy one, not actually correlated with a private key)
 RSA_PUBLIC_KEY=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF0QTBrU0VwaW10VjA1WGlRcmFWQjkKQWZEZU1xRlpPcTNGU1hNOTJPbGI0NEdWR1ZqY3V5dmdVeWFDaTZiMzNhNHBHaGp4b00weGRVT2gvb0NJRUFEawo3cThBSjdRV3JmU0NyZ3ZSTW42RFNuTEJQU0d4WWlPdnExNUhIMUVsZmtTVXVSSDZNN1BKb0VkNlBFRDB5dFdLCnFNcXpiSFhFMEs2cEI3Y05vNmdCUjYwaHNjZ2FXVlhPMUtybDFEcVo5ZHVRME1CSXlIcitZU1pkRjhTUWdUOW4KWitKbGtmR2xuNWxkZDRBNXlKQUxJb0VZQW1VUW1SR0UyNlRIWHhuZS9Mclk5NmZwM3hlRFpUMHQ0d0hZYmU1WQp6S2hvT05rNjByK1h5M3hBUmNBUXNuOTlLaTFIY2oyV0tvOFkyNmpxNlVqVVkzSHBQYlB4MTBNM2pFUkpPZTF4CndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t
 
-# Required: Keycloak admin username for Terraform provider
-# Do NOT use default/weak usernames like 'admin' or 'user'
-KEYCLOAK_ADMIN_USERNAME=myadminuser
+# Required: Keycloak admin credentials for Terraform provider
+# These credentials are used for:
+# 1. Logging into Keycloak admin console at https://keycloak.<EXTERNAL_IP>.nip.io
+# 2. Terraform provider authentication for resource management
+# SECURITY: Do NOT use default/weak credentials - deployment will fail if not set
+KEYCLOAK_ADMIN_USERNAME=
+KEYCLOAK_ADMIN_PASSWORD=
+
+# Required: Portal test user credentials
+# Used for logging into the portal at https://<EXTERNAL_IP>.nip.io
+# SECURITY: Change these to secure credentials - deployment will fail if password not set
+KEYCLOAK_ADMIN_TEST_USERNAME=testadmin
+KEYCLOAK_ADMIN_TEST_PASSWORD=
 
 # Required: Docker registry credentials for private image pulls
 # These are only needed once due to Terraform lifecycle.ignore_changes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,26 @@ A lightweight, single-VM lite version of the [Pilot-HDC](https://hdc.humanbrainp
    EXTERNAL_IP=192.168.1.100  # Your VM IP
    RSA_PUBLIC_KEY="<your-public-key>"
    DEMO=true  # Required: Set to 'true' to accept self-signed certificates
+              # ⚠️ SECURITY: Skips TLS verification during Terraform bootstrap
+              # Only use on isolated/trusted networks (dev/demo environments)
+              # For production: Configure proper CA-signed certificates and set DEMO=false
+
+   # Keycloak admin console credentials
+   KEYCLOAK_ADMIN_USERNAME="myadminuser"  # **CHANGE THIS**
+   KEYCLOAK_ADMIN_PASSWORD="SecurePass123"  # **REQUIRED**
+
+   # Portal login credentials
+   KEYCLOAK_ADMIN_TEST_USERNAME="testadmin"  # **CHANGE THIS**
+   KEYCLOAK_ADMIN_TEST_PASSWORD="PortalPass456"  # **REQUIRED**
    ```
+
+   **⚠️ Security Requirements**:
+   - **Keycloak Admin Console** (`https://keycloak.<EXTERNAL_IP>.nip.io`):
+     - Username: `KEYCLOAK_ADMIN_USERNAME` (do NOT use 'admin' or 'user')
+     - Password: `KEYCLOAK_ADMIN_PASSWORD` (required - deployment fails if not set)
+   - **Portal Login** (`https://<EXTERNAL_IP>.nip.io`):
+     - Username: `KEYCLOAK_ADMIN_TEST_USERNAME` (default: 'testadmin')
+     - Password: `KEYCLOAK_ADMIN_TEST_PASSWORD` (required - deployment fails if not set)
 
    **Note**: This platform uses self-signed certificates from cert-manager. You must set `DEMO=true` to allow Terraform to deploy. See [Demo Mode Configuration](#demo-mode-configuration) below.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,6 +32,25 @@ if [[ -z "${RSA_PUBLIC_KEY}" ]]; then
     exit 1
 fi
 
+if [[ -z "${KEYCLOAK_ADMIN_USERNAME}" ]]; then
+    echo "ERROR: KEYCLOAK_ADMIN_USERNAME must be set in .env file"
+    exit 1
+fi
+
+if [[ -z "${KEYCLOAK_ADMIN_PASSWORD}" ]]; then
+    echo "ERROR: KEYCLOAK_ADMIN_PASSWORD must be set in .env file"
+    echo "SECURITY: This password is required for Keycloak admin console access"
+    echo "Please set a strong password in your .env file"
+    exit 1
+fi
+
+if [[ -z "${KEYCLOAK_ADMIN_TEST_PASSWORD}" ]]; then
+    echo "ERROR: KEYCLOAK_ADMIN_TEST_PASSWORD must be set in .env file"
+    echo "INFO: This password is for portal login (username: ${KEYCLOAK_ADMIN_TEST_USERNAME:-testadmin})"
+    echo "Please set a strong password in your .env file"
+    exit 1
+fi
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -116,11 +135,50 @@ run_ansible() {
 
 run_terraform() {
     log "Checking for Terraform..."
-    
+
     if command -v terraform >/dev/null 2>&1; then
         log "Running Terraform deployment with external IP: ${EXTERNAL_IP}..."
         cd "${SCRIPT_DIR}/terraform"
+
+        # Check if this is a fresh deployment (Keycloak doesn't exist yet)
+        if ! kubectl get namespace keycloak &>/dev/null 2>&1; then
+            log "Fresh deployment detected - deploying Keycloak infrastructure first..."
+
+            # Source .env and export Terraform variables (required for targeted apply)
+            source "${SCRIPT_DIR}/.env"
+            export TF_VAR_external_ip="${EXTERNAL_IP}"
+            export TF_VAR_docker_registry_username="${DOCKER_REGISTRY_USERNAME:-}"
+            export TF_VAR_docker_registry_password="${DOCKER_REGISTRY_PASSWORD:-}"
+            export TF_VAR_docker_registry_external_username="${DOCKER_REGISTRY_EXTERNAL_USERNAME:-}"
+            export TF_VAR_docker_registry_external_password="${DOCKER_REGISTRY_EXTERNAL_PASSWORD:-}"
+            export TF_VAR_rsa_public_key="${RSA_PUBLIC_KEY:-}"
+            export TF_VAR_demo_mode="${DEMO:-false}"
+            export TF_VAR_keycloak_admin_username="${KEYCLOAK_ADMIN_USERNAME}"
+            export TF_VAR_keycloak_admin_password="${KEYCLOAK_ADMIN_PASSWORD}"
+            export TF_VAR_keycloak_admin_test_username="${KEYCLOAK_ADMIN_TEST_USERNAME:-testadmin}"
+            export TF_VAR_keycloak_admin_test_password="${KEYCLOAK_ADMIN_TEST_PASSWORD}"
+
+            terraform init
+            terraform apply -auto-approve \
+                -target=kubernetes_namespace.keycloak \
+                -target=helm_release.keycloak_postgres \
+                -target=helm_release.keycloak
+
+            log "Waiting for Keycloak pods to be ready (timeout: 5 minutes)..."
+            kubectl wait --for=condition=ready pod \
+                -l app.kubernetes.io/name=keycloak \
+                -n keycloak \
+                --timeout=300s || warn "Keycloak pod readiness check timed out, continuing anyway..."
+
+            # Brief additional wait for service initialization
+            log "Waiting for Keycloak service initialization..."
+            sleep 10
+        fi
+
+        # Run full deployment (will be no-op for Keycloak on fresh, updates on existing)
+        log "Running full Terraform deployment..."
         ./run.sh --auto-approve
+
         cd "${SCRIPT_DIR}"
         log "Terraform deployment completed"
     else
@@ -141,9 +199,10 @@ show_status() {
         echo ""
         
         echo "=== Access Information ==="
-        echo "Keycloak should be accessible at: http://keycloak.${EXTERNAL_IP}.nip.io"
-        echo "MinIO Console should be accessible at: http://minio-console.${EXTERNAL_IP}.nip.io"
-        echo "MinIO API should be accessible at: http://minio-api.${EXTERNAL_IP}.nip.io"
+        echo "Portal should be accessible at: https://${EXTERNAL_IP}.nip.io"
+        echo "Keycloak should be accessible at: https://keycloak.${EXTERNAL_IP}.nip.io"
+        echo "MinIO Console should be accessible at: https://minio-console.${EXTERNAL_IP}.nip.io"
+        echo "MinIO API should be accessible at: https://minio-api.${EXTERNAL_IP}.nip.io"
         echo "Platform external IP: ${EXTERNAL_IP}"
         echo "(Once all services are deployed and running)"
     else

--- a/helm_charts/pilot-hdc/auth/values.yaml
+++ b/helm_charts/pilot-hdc/auth/values.yaml
@@ -5,7 +5,7 @@ appConfig:
 
 image:
   repository: docker-registry.ebrains.eu/hdc-services-image/auth
-  tag: 2.2.27
+  # tag: set by Terraform via var.auth_app_version
   pullPolicy: IfNotPresent
 
 fullnameOverride: auth
@@ -38,7 +38,7 @@ extraEnv:
   # Keycloak configuration - uses HTTPS external ingress
   KEYCLOAK_SERVER_URL: "https://keycloak.${EXTERNAL_IP}.nip.io"
   KEYCLOAK_CLIENT_ID: "pilot-hdc-lite"
-  KEYCLOAK_REALM: "master"
+  KEYCLOAK_REALM: "hdc"
   KEYCLOAK_ID: "pilot-hdc-lite"
   # Redis configuration
   REDIS_HOST: "redis-master.redis"

--- a/helm_charts/pilot-hdc/bff/values.yaml
+++ b/helm_charts/pilot-hdc/bff/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker-registry.ebrains.eu/hdc-services-image/bff-web
-  tag: 2.2.68
+  # tag: set by Terraform via var.bff_app_version
   pullPolicy: IfNotPresent
   tagPrefix: "bff"
 
@@ -20,6 +20,7 @@ container:
 
 service:
   type: ClusterIP
+  port: 5060  # Main API port for ingress backend
   ports:
     - port: 5060
       targetPort:
@@ -38,7 +39,7 @@ extraEnv:
   CORE_ZONE_LABEL: "Core"
   GREENROOM_ZONE_LABEL: "Greenroom"
   PROJECT_NAME: "Pilot HDC Lite"
-  KEYCLOAK_REALM: "master"
+  KEYCLOAK_REALM: "hdc"
   AD_USER_GROUP: "users"
   AD_PROJECT_GROUP_PREFIX: "pilot-hdc"
   EMAIL_SUPPORT: "support@pilot-hdc-lite.local"

--- a/helm_charts/pilot-hdc/dataops/values.yaml
+++ b/helm_charts/pilot-hdc/dataops/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker-registry.ebrains.eu/hdc-services-image/dataops
-  tag: 274
+  # tag: set by Terraform via var.dataops_app_version
   pullPolicy: IfNotPresent
 
 deploymentAnnotations:

--- a/helm_charts/pilot-hdc/metadata/values.yaml
+++ b/helm_charts/pilot-hdc/metadata/values.yaml
@@ -5,7 +5,7 @@ appConfig:
 
 image:
   repository: docker-registry.ebrains.eu/hdc-services-image/metadata
-  tag: 251
+  # tag: set by Terraform via var.metadata_app_version
   pullPolicy: IfNotPresent
 
 fullnameOverride: metadata

--- a/helm_charts/pilot-hdc/portal/values.yaml
+++ b/helm_charts/pilot-hdc/portal/values.yaml
@@ -1,0 +1,105 @@
+image:
+  repository: docker-registry.ebrains.eu/hdc-services-image/portal
+  # tag: set by Terraform via var.portal_app_version
+  pullPolicy: IfNotPresent
+
+fullnameOverride: portal
+
+container:
+  port: 80
+
+service:
+  type: ClusterIP
+  port: 3000
+  targetPort: 80
+
+# Single replica for alpha (vs 3 in production)
+replicaCount: 1
+
+# Minimal resources for 16GB RAM constraint
+resources:
+  requests:
+    memory: "50Mi"
+    cpu: "10m"
+  limits:
+    memory: "100Mi"
+    cpu: "100m"
+
+appConfig:
+  env: "staging"
+
+  # Basic configuration
+  REACT_APP_PORTAL_PATH: ""
+  REACT_APP_BRANDING_PATH: "/login"
+  REACT_APP_SOCKET_PROTOCOL: "wss"
+  REACT_APP_PLATFORM: "Pilot HDC Lite"
+
+  # Support contact
+  REACT_APP_SUPPORT_EMAIL: "support@pilot-hdc-lite.local"
+  REACT_APP_ORGANIZATION_PORTAL_DOMAIN: "pilot-hdc-lite.local"
+
+  # Domain and auth - will be injected via templatefile
+  REACT_APP_DOMAIN: "${EXTERNAL_IP}.nip.io"
+  REACT_APP_DEFAULT_AUTH_URL: "https://keycloak.${EXTERNAL_IP}.nip.io"
+  REACT_APP_KEYCLOAK_REALM: "hdc"
+
+  # BFF API endpoints - will be injected via templatefile
+  REACT_APP_API_PATH: "https://api.${EXTERNAL_IP}.nip.io"
+
+  # Download paths (relative to BFF)
+  REACT_APP_DOWNLOAD_URL_V2: "/download/core/v2/dataset/download"
+  REACT_APP_DOWNLOAD_URL_V1: "/download/core/v1/download"
+  REACT_APP_PROXY_ROUTE: "/pilot/api"
+
+  # Alpha simplifications - arranger/search not available
+  REACT_APP_ARRANGER_API: ""
+  REACT_APP_ARRANGER_GRAPHQLFIELD: ""
+  REACT_APP_ARRANGER_PROJECTID: ""
+
+  # Self-registration disabled for alpha
+  REACT_APP_ENABLE_SELF_REGISTRATION: "false"
+
+  # No superset in alpha
+  REACT_APP_SUPERSET_SUBDOMAIN: "false"
+  REACT_APP_SUPERSET_SUBDOMAIN_BASE: ""
+
+  # No remote branding module
+  REACT_APP_REMOTE_MODULE_BRANDING_URL: ""
+
+  # Placeholder for public docs (not configured in alpha)
+  REACT_APP_DOC_BUCKET: ""
+
+readinessProbe:
+  tcpSocket:
+    port: 80
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 80
+    scheme: HTTP
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: self-signed
+    kubernetes.io/ingress.class: traefik
+  tls: true
+  hostname: "${EXTERNAL_IP}.nip.io"
+  path: /
+  pathType: Prefix
+
+# No pod anti-affinity for single-node k3s
+affinity: {}
+
+# Simple rolling update for alpha
+updateStrategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+  type: RollingUpdate

--- a/helm_charts/pilot-hdc/project/values.yaml
+++ b/helm_charts/pilot-hdc/project/values.yaml
@@ -8,7 +8,7 @@ deploymentAnnotations:
 
 image:
   repository: docker-registry.ebrains.eu/hdc-services-image/project
-  tag: 251
+  # tag: set by Terraform via var.project_app_version
   pullPolicy: IfNotPresent
 
 fullnameOverride: project

--- a/terraform/keycloak-client.tf
+++ b/terraform/keycloak-client.tf
@@ -1,18 +1,10 @@
 # Keycloak Client Configuration for Auth Service
 # Uses Terraform Keycloak provider to manage OIDC client declaratively
-
-# Read Keycloak admin credentials from the Keycloak Helm release
-data "kubernetes_secret" "keycloak_admin" {
-  metadata {
-    name      = "keycloak"
-    namespace = "keycloak"
-  }
-  depends_on = [helm_release.keycloak]
-}
+# Note: Admin credentials are provided via variables (keycloak_admin_username/password)
 
 # Create OIDC client for pilot-hdc-lite auth service
 resource "keycloak_openid_client" "pilot_hdc_lite" {
-  realm_id  = "master"  # Using master realm for alpha
+  realm_id  = keycloak_realm.hdc.id
   client_id = "pilot-hdc-lite"
 
   name    = "Pilot HDC Lite Auth Service"
@@ -44,7 +36,7 @@ resource "keycloak_openid_client" "pilot_hdc_lite" {
 
 # Configure default scopes for the client
 resource "keycloak_openid_client_default_scopes" "pilot_hdc_lite" {
-  realm_id  = "master"
+  realm_id  = keycloak_realm.hdc.id
   client_id = keycloak_openid_client.pilot_hdc_lite.id
 
   default_scopes = [

--- a/terraform/keycloak-realm.tf
+++ b/terraform/keycloak-realm.tf
@@ -1,0 +1,201 @@
+# Keycloak HDC Realm Configuration
+# Creates dedicated realm for pilot-hdc-lite with react-app public client
+
+# HDC Realm
+resource "keycloak_realm" "hdc" {
+  realm             = var.keycloak_realm_name
+  enabled           = true
+  display_name      = "Pilot HDC Lite"
+  display_name_html = "<h1>Pilot HDC Lite</h1>"
+
+  login_with_email_allowed = true
+  user_managed_access      = true
+  reset_password_allowed   = true
+
+  # Simplified security
+  security_defenses {
+    brute_force_detection {
+      permanent_lockout                = false
+      max_login_failures               = 5
+      wait_increment_seconds           = 60
+      quick_login_check_milli_seconds  = 1000
+      minimum_quick_login_wait_seconds = 60
+      max_failure_wait_seconds         = 900
+      failure_reset_time_seconds       = 43200
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Realm Roles
+# -----------------------------------------------------------------------------
+
+# Get built-in offline_access role
+data "keycloak_role" "offline_access" {
+  realm_id = keycloak_realm.hdc.id
+  name     = "offline_access"
+}
+
+# Platform admin role
+resource "keycloak_role" "platform_admin" {
+  realm_id    = keycloak_realm.hdc.id
+  name        = "platform-admin"
+  description = "Platform Administrator Role"
+
+  composite_roles = [
+    data.keycloak_role.offline_access.id
+  ]
+}
+
+# Admin role
+resource "keycloak_role" "admin_role" {
+  realm_id    = keycloak_realm.hdc.id
+  name        = "admin-role"
+  description = "Administrator Role"
+
+  composite_roles = [
+    data.keycloak_role.offline_access.id
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# react-app Client (PUBLIC client for Portal SPA)
+# -----------------------------------------------------------------------------
+
+resource "keycloak_openid_client" "react_app" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = "react-app"
+
+  name    = "React Portal Application"
+  enabled = true
+
+  # PUBLIC client - no client secret for browser-based SPAs
+  access_type                  = "PUBLIC"
+  standard_flow_enabled        = true
+  direct_access_grants_enabled = true
+
+  # Valid redirect URIs - allow all paths on portal domain
+  valid_redirect_uris = [
+    "https://${var.external_ip}.nip.io/*"
+  ]
+
+  # Web origins for CORS
+  web_origins = [
+    "https://${var.external_ip}.nip.io"
+  ]
+
+  # Base URL
+  base_url = "https://${var.external_ip}.nip.io"
+
+  backchannel_logout_session_required = false
+}
+
+# Configure default scopes for react-app client
+resource "keycloak_openid_client_default_scopes" "react_app" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "groups",
+    "openid"
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# Protocol Mappers for MinIO Integration
+# -----------------------------------------------------------------------------
+
+# MinIO policy mapper - maps user attribute "policy" to token claims
+resource "keycloak_openid_user_attribute_protocol_mapper" "react_app_minio_policy" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+  name      = "minio_policy_mapper"
+
+  user_attribute   = "policy"
+  claim_name       = "policy"
+  claim_value_type = "String"
+
+  add_to_id_token      = true
+  add_to_access_token  = true
+  add_to_userinfo      = true
+}
+
+# MinIO audience mapper - adds "minio" as custom audience
+resource "keycloak_openid_audience_protocol_mapper" "react_app_minio_audience" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+  name      = "aud_mapper"
+
+  included_custom_audience = "minio"
+  add_to_id_token          = false
+}
+
+# Client ID session note mapper
+resource "keycloak_openid_user_session_note_protocol_mapper" "react_app_client_id" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+  name      = "Client ID"
+
+  session_note     = "clientId"
+  claim_name       = "clientId"
+  claim_value_type = "String"
+}
+
+# Client IP address session note mapper
+resource "keycloak_openid_user_session_note_protocol_mapper" "react_app_client_ip" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+  name      = "Client IP Address"
+
+  session_note     = "clientAddress"
+  claim_name       = "clientAddress"
+  claim_value_type = "String"
+}
+
+# Client host session note mapper
+resource "keycloak_openid_user_session_note_protocol_mapper" "react_app_client_host" {
+  realm_id  = keycloak_realm.hdc.id
+  client_id = keycloak_openid_client.react_app.id
+  name      = "Client Host"
+
+  session_note     = "clientHost"
+  claim_name       = "clientHost"
+  claim_value_type = "String"
+}
+
+# -----------------------------------------------------------------------------
+# Test Admin User
+# -----------------------------------------------------------------------------
+
+resource "keycloak_user" "admin" {
+  realm_id = keycloak_realm.hdc.id
+  username = var.keycloak_admin_test_username
+
+  email          = "${var.keycloak_admin_test_username}@pilot-hdc-lite.local"
+  email_verified = true
+  enabled        = true
+
+  first_name = "Admin"
+  last_name  = "User"
+
+  initial_password {
+    value     = var.keycloak_admin_test_password
+    temporary = false
+  }
+}
+
+# Assign platform-admin role to admin user
+resource "keycloak_user_roles" "admin_platform_admin" {
+  realm_id = keycloak_realm.hdc.id
+  user_id  = keycloak_user.admin.id
+
+  role_ids = [
+    keycloak_role.platform_admin.id,
+    keycloak_role.admin_role.id,
+    data.keycloak_role.offline_access.id
+  ]
+}

--- a/terraform/keycloak.tf
+++ b/terraform/keycloak.tf
@@ -24,6 +24,17 @@ resource "helm_release" "keycloak" {
     value = "keycloak.${local.node_ip}.nip.io"
   }
 
+  # Set admin credentials from variables (required for security)
+  set {
+    name  = "auth.adminUser"
+    value = var.keycloak_admin_username
+  }
+
+  set_sensitive {
+    name  = "auth.adminPassword"
+    value = var.keycloak_admin_password
+  }
+
   depends_on = [
     helm_release.keycloak_postgres
   ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,7 +44,7 @@ provider "kubectl" {
 provider "keycloak" {
   client_id                = "admin-cli"
   username                 = var.keycloak_admin_username
-  password                 = data.kubernetes_secret.keycloak_admin.data["admin-password"]
+  password                 = var.keycloak_admin_password
   url                      = var.keycloak_url != "" ? var.keycloak_url : "https://keycloak.${var.external_ip}.nip.io"
   tls_insecure_skip_verify = var.demo_mode  # Only skip TLS verification in demo mode
 }

--- a/terraform/run.sh
+++ b/terraform/run.sh
@@ -21,6 +21,9 @@ export TF_VAR_docker_registry_external_password="${DOCKER_REGISTRY_EXTERNAL_PASS
 export TF_VAR_rsa_public_key="${RSA_PUBLIC_KEY:-}"
 export TF_VAR_demo_mode="${DEMO:-false}"
 export TF_VAR_keycloak_admin_username="${KEYCLOAK_ADMIN_USERNAME}"
+export TF_VAR_keycloak_admin_password="${KEYCLOAK_ADMIN_PASSWORD}"
+export TF_VAR_keycloak_admin_test_username="${KEYCLOAK_ADMIN_TEST_USERNAME:-testadmin}"
+export TF_VAR_keycloak_admin_test_password="${KEYCLOAK_ADMIN_TEST_PASSWORD}"
 
 # Check for auto-approve flag
 AUTO_APPROVE=false
@@ -38,8 +41,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Ensure state directory exists
-mkdir -p /home/ubuntu/.terraform-state
+# Ensure state directory exists with restricted permissions
+install -d -m 700 /home/ubuntu/.terraform-state
 
 terraform init
 terraform plan -out deploy.tfplan

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -146,9 +146,25 @@ variable "bff_app_version" {
   default = "2.2.68"
 }
 
+variable "portal_chart_version" {
+  type    = string
+  default = "2.1.2"
+}
+
+variable "portal_app_version" {
+  type    = string
+  default = "1.5.3-hdc-lite"
+}
+
 variable "keycloak_admin_username" {
   type        = string
   description = "Keycloak admin username (must be explicitly set for security)"
+  sensitive   = true
+}
+
+variable "keycloak_admin_password" {
+  type        = string
+  description = "Keycloak admin password (must be explicitly set for security - no default)"
   sensitive   = true
 }
 
@@ -162,4 +178,23 @@ variable "demo_mode" {
   type        = bool
   description = "Enable demo mode: Terraform provider accepts self-signed certificates. Set to false to require CA-signed certificates."
   default     = false
+}
+
+variable "keycloak_realm_name" {
+  type        = string
+  description = "Name of the Keycloak realm for pilot-hdc-lite"
+  default     = "hdc"
+}
+
+variable "keycloak_admin_test_username" {
+  type        = string
+  description = "Username for portal test admin user (HDC realm)"
+  default     = "testadmin"
+  sensitive   = false
+}
+
+variable "keycloak_admin_test_password" {
+  type        = string
+  description = "Password for portal test admin user (HDC realm)"
+  sensitive   = true
 }


### PR DESCRIPTION
Add portal service deployment with custom 1.5.3-hdc-lite image and Keycloak HDC realm configuration. Implement security hardening with required password management and two-stage Keycloak deployment for fresh VMs.

Key changes:
- Portal service deployed at root domain with react-app PUBLIC client
- Keycloak HDC realm with protocol mappers for MinIO integration
- Required admin and test user credentials via environment variables
- Two-stage Keycloak deployment: infrastructure first, then configuration
- Terraform state directory permissions (mode 700)
- Remove BFF direct API ingress (Kong will handle API routing)
- All services now use HDC realm instead of master realm

Portal authentication works but API calls blocked pending Kong deployment.