### PR TITLE
IEBH-464: Increase services response timeout

### DIFF
--- a/helm_charts/pilot-hdc/bff/values.yaml
+++ b/helm_charts/pilot-hdc/bff/values.yaml
@@ -54,6 +54,7 @@ extraEnv:
   S3_GATEWAY: "True"
   INVITATION_URL_LOGIN: "https://${EXTERNAL_IP}/login/"
   # Alpha - services that ARE deployed
+  SERVICE_CLIENT_TIMEOUT: 30
   AUTH_SERVICE: "http://auth.utility:5061"
   METADATA_SERVICE: "http://metadata.utility:5066"
   PROJECT_SERVICE: "http://project.utility:5064"


### PR DESCRIPTION
Increase default 5 seconds timeout up to 30 seconds due to possible delays when running lite version.